### PR TITLE
Switch api calls to use async

### DIFF
--- a/Bakus Addition.swiftpm/.swiftpm/playgrounds/CachedManifest.plist
+++ b/Bakus Addition.swiftpm/.swiftpm/playgrounds/CachedManifest.plist
@@ -12,7 +12,7 @@
 		cHJvZHVjdHMiOlt7Im5hbWUiOiJCYWt1cyIsInNldHRpbmdzIjpbeyJidW5k
 		bGVJZGVudGlmaWVyIjpbImlvLnNlaW0uYmFrdXMiXX0seyJ0ZWFtSWRlbnRp
 		ZmllciI6WyI3TDlKSE41VE1GIl19LHsiZGlzcGxheVZlcnNpb24iOlsiMC4x
-		LjAiXX0seyJidW5kbGVWZXJzaW9uIjpbIjMiXX0seyJpT1NBcHBJbmZvIjpb
+		LjAiXX0seyJidW5kbGVWZXJzaW9uIjpbIjQiXX0seyJpT1NBcHBJbmZvIjpb
 		eyJhY2NlbnRDb2xvciI6eyJwcmVzZXRDb2xvciI6eyJwcmVzZXRDb2xvciI6
 		eyJyYXdWYWx1ZSI6InB1cnBsZSJ9fX0sImFwcENhdGVnb3J5Ijp7InJhd1Zh
 		bHVlIjoicHVibGljLmFwcC1jYXRlZ29yeS51dGlsaXRpZXMifSwiYXBwSWNv
@@ -34,7 +34,7 @@
 		</data>
 		<key>manifestHash</key>
 		<data>
-		1fV3GwmrvVogIKy3rtULNWMxDb4iNvSP8ZkG8tytffw=
+		fpSjDEGDva6p6lhfXJlyc5BDr81gbsw2c7IFSYkotys=
 		</data>
 		<key>schemaVersion</key>
 		<integer>4</integer>

--- a/Bakus Addition.swiftpm/Package.swift
+++ b/Bakus Addition.swiftpm/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
             bundleIdentifier: "io.seim.bakus",
             teamIdentifier: "7L9JHN5TMF",
             displayVersion: "0.1.0",
-            bundleVersion: "3",
+            bundleVersion: "4",
             appIcon: .asset("AppIcon"),
             accentColor: .presetColor(.purple),
             supportedDeviceFamilies: [


### PR DESCRIPTION
Other than looking a lot cleaner without all the callbacks, this also enables the refresh spinner to spin while the network calls are being made.